### PR TITLE
fix: flyway pattern _##__whatever.sql

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 dirname=$1
-find "$dirname" -type f | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
+find "$dirname" -type f | sed 's!.*/!!' | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
 while read fileName
 do
   find $dirname -type f | grep "${fileName}" |

--- a/check.sh
+++ b/check.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 dirname=$1
-find $dirname -type f  | sed 's_.*/__' | awk -F"__" '{print $1}' | sort | uniq -d |
+find "$dirname" -type f | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
 while read fileName
 do
   find $dirname -type f | grep "${fileName}" |

--- a/script.sh
+++ b/script.sh
@@ -15,8 +15,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 
 echo Scanning ${INPUT_DIRECTORY}
 
-find ${INPUT_DIRECTORY} -type f  | sed 's_.*/__' | awk -F"__" '{print $1}' | sort | uniq -d |
-find "${INPUT_DIRECTORY}" -type f | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
+find "${INPUT_DIRECTORY}" -type f | sed 's!.*/!!' | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
 while read fileName
 do
   find $dirname -type f | grep "${fileName}" |

--- a/script.sh
+++ b/script.sh
@@ -16,6 +16,7 @@ export REVIEWDOG_GITHUB_API_TOKEN="${INPUT_GITHUB_TOKEN}"
 echo Scanning ${INPUT_DIRECTORY}
 
 find ${INPUT_DIRECTORY} -type f  | sed 's_.*/__' | awk -F"__" '{print $1}' | sort | uniq -d |
+find "${INPUT_DIRECTORY}" -type f | sed 's/\(.*_[0-9]*\)__.*/\1/g;t' | sort | uniq -d |
 while read fileName
 do
   find $dirname -type f | grep "${fileName}" |


### PR DESCRIPTION
**Deduplication logic improvements:**

* Updated the `sed` command in both `check.sh` and `script.sh` to use a regular expression that extracts file name prefixes ending with an underscore and digits, improving accuracy when identifying duplicates.  Look for number and then "__" as the split where everything after is arbitrary, and the prefix is the key to dedup.

Examples where "R__" was creating false positive.

```
R__20__citest_insert_into_program.sql
R__21__citest_insert_into_mention.sql
R__22__citest_shared.shared_url_2020_01_03-04.sql
R__23__citest_shared.shared_url_2020_03_11.sql
R__24__citest_shared.shared_url_2020_03_12.sql
R__26__insert_into_tree_object_closure.sql
R__28__citest_schedule_job.sql
R__29__citest_test_organizations.sql
U2_08__add_canadian_markets.sql
V1_01__create_dababase_or_grant_select_to_postgres_on_flyway_table.sql
V1_02__non_transactional.sql
V2_01__add_collumns_to_tracking_unit_table.sql
V2_02__alter_tracking_unit_enable_expire_notification.sql
V2_03__add_application_id_in_organization.sql
V2_04__add_new_tracking_type_value_live_prerecorded.sql
```

Evidence:

```shell
❯ ./check.sh "/Volumes/veritone/aiware-core/services/api/core-graphql-server/flyway/db/platform/sql"
/Volumes/veritone/aiware-core/services/api/core-graphql-server/flyway/db/platform/sql/V3_273__add_ingest_slugs_delete_by_source_event.sql:1:1: Duplicate filename -- V3_273
/Volumes/veritone/aiware-core/services/api/core-graphql-server/flyway/db/platform/sql/V3_273__recording_clone_mapping.sql:1:1: Duplicate filename -- V3_273
```